### PR TITLE
Feat/admin: 관리자 페이지 용 유저 관리 API

### DIFF
--- a/src/api/users/users.controller.ts
+++ b/src/api/users/users.controller.ts
@@ -35,11 +35,6 @@ export class UsersController {
     return await this.usersService.findAll();
   }
 
-  @Get('sdf')
-  getsdf() {
-    console.log('sdf');
-  }
-
   @HttpCode(200)
   @Get('/profile')
   async getProfile(@AuthUser() user) {


### PR DESCRIPTION
### 📟 연결된 이슈
#8


### 👷 작업한 내용
- 전체 유저 조회 API(GET /users) with query(page, name)
- id로 특정 유저 조회(GET /users/:userId)
- id로 특정 유저 정보 수정(PATCH /users/:userId) with Body

### 문제 해결
- JwtGuard가 특정 API(GET /users/profile)에서 두 번 적용되어 두 번째 가드에서 user 정보가 null이 들어가 해당 API가 제대로 실행되지 않던 문제가 있었음.
- 해당 Route의 위치를 path parameter를 가지는 /users/userId 위로 올리니 문제가 해결되었음.
- 해당 문제는 라우트 순서와 가드 적용 방식 때문일 수 있다. JwtGuard가 두 번 적용되었는데, 이는 첫 번째 가드에서 사용자 정보를 성공적으로 설정했음에도 불구하고, 두 번째 가드에서 그 정보가 null로 재설정되었을 가능성이 있다. 이는 아마도 GET /users/:userId 라우트에 적용된 가드가 GET /users/profile 라우트로의 요청을 가로채서 처리하려고 했기 때문일 수 있다.
- NestJS와 다른 많은 웹 프레임워크에서는 라우트가 정의된 순서가 중요하다. 프레임워크는 들어오는 요청을 처리할 때 상위에서 하위로 정의된 순서대로 라우트를 평가한다. 따라서, 더 구체적인 경로(예: /users/profile)를 더 일반적인 경로(예: /users/:userId)보다 먼저 정의해야 한다. 그렇지 않으면, 일반적인 경로가 더 구체적인 경로의 요청을 가로챌 수 있다.


### 📸 스크린샷
