### PR TITLE
feat: 파일 업로드 저장 기능

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ lerna-debug.log*
 !.vscode/extensions.json
 
 .env
+
+/public

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "@types/cookie-parser": "^1.4.6",
         "@types/express": "^4.17.17",
         "@types/jest": "^29.5.2",
+        "@types/multer": "^1.4.11",
         "@types/node": "^20.3.1",
         "@types/passport-jwt": "^4.0.1",
         "@types/passport-kakao": "^1.0.3",
@@ -2714,6 +2715,15 @@
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
       "dev": true
+    },
+    "node_modules/@types/multer": {
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.11.tgz",
+      "integrity": "sha512-svK240gr6LVWvv3YGyhLlA+6LRRWA4mnGIU7RcNmgjBYFl6665wcXrRfxGp5tEPVHUNm5FMcmq7too9bxCwX/w==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "20.11.16",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@types/cookie-parser": "^1.4.6",
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.2",
+    "@types/multer": "^1.4.11",
     "@types/node": "^20.3.1",
     "@types/passport-jwt": "^4.0.1",
     "@types/passport-kakao": "^1.0.3",

--- a/src/api/admin/admin.controller.ts
+++ b/src/api/admin/admin.controller.ts
@@ -1,8 +1,18 @@
-import { Body, Controller, Get, Param, Patch, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Req,
+  UseInterceptors,
+} from '@nestjs/common';
 import { AdminService } from './admin.service';
 import { UpdateCourseDto } from './dto/update-course.dto';
-import { FormDataRequest } from 'nestjs-form-data';
 import { UpdateLecturesDto } from './dto/update-lectures.dto';
+import { FileUploadInterceptor } from './interceptor/fileUploadInterceptor';
+import { Request } from 'express';
 
 @Controller('admin')
 export class AdminController {
@@ -30,13 +40,18 @@ export class AdminController {
   }
 
   @Patch('/courses/:courseId')
-  @FormDataRequest()
+  // @FormDataRequest()
+  // @UseInterceptors(FileInterceptor('thumbnailImage'))
+  @UseInterceptors(FileUploadInterceptor)
   async create(
     @Param('courseId') courseId: number,
     @Body() updateCourseDto: UpdateCourseDto,
+    @Req() req: Request,
   ) {
     console.log(updateCourseDto);
-    await this.adminService.updateCourse(courseId, updateCourseDto);
+    const filepath = req['filepath']; // 파일 경로 접근
+    console.log(filepath);
+    await this.adminService.updateCourse(courseId, updateCourseDto, filepath);
     return { message: 'Course updated successfully' };
   }
 
@@ -48,5 +63,11 @@ export class AdminController {
     console.log(updateLecturesDto);
     await this.adminService.updateLectures(courseId, updateLecturesDto);
     return { message: 'Course updated successfully' };
+  }
+
+  @Get('/curriculum')
+  async findAllCurriculums() {
+    const result = await this.adminService.findAllCurriculums();
+    return { data: result };
   }
 }

--- a/src/api/admin/dto/update-course.dto.ts
+++ b/src/api/admin/dto/update-course.dto.ts
@@ -1,18 +1,5 @@
 import { Expose } from 'class-transformer';
 import { IsNotEmpty, IsOptional } from 'class-validator';
-import {
-  FileSystemStoredFile,
-  HasMimeType,
-  IsFile,
-  MaxFileSize,
-} from 'nestjs-form-data';
-
-// export interface LectureDto {
-//   lectureId?: number;
-//   title: string;
-//   videoLink: string;
-//   lectureNumber: number;
-// }
 
 export class LectureDto {
   @IsOptional()
@@ -33,17 +20,17 @@ export class LectureDto {
 }
 
 export class UpdateCourseDto {
-  @IsFile()
-  @IsOptional()
-  @MaxFileSize(1e8, {
-    message: '파일의 최대 사이즈는 100MB입니다',
-  })
-  @HasMimeType(['image/png', 'image/jpeg', 'image/jpg'], {
-    message: (e) => {
-      return `error: ${e.constraints}`;
-    },
-  })
-  thumbnailImage: FileSystemStoredFile;
+  // @IsFile()
+  // @IsOptional()
+  // @MaxFileSize(1e8, {
+  //   message: '파일의 최대 사이즈는 100MB입니다',
+  // })
+  // @HasMimeType(['image/png', 'image/jpeg', 'image/jpg'], {
+  //   message: (e) => {
+  //     return `error: ${e.constraints}`;
+  //   },
+  // })
+  // thumbnailImage: FileSystemStoredFile;
 
   @IsNotEmpty()
   @IsOptional()

--- a/src/api/admin/interceptor/fileUploadInterceptor.ts
+++ b/src/api/admin/interceptor/fileUploadInterceptor.ts
@@ -1,0 +1,72 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  UnsupportedMediaTypeException,
+  PayloadTooLargeException,
+  CallHandler,
+} from '@nestjs/common';
+import { HttpArgumentsHost } from '@nestjs/common/interfaces';
+import multer from 'multer';
+import { FileFilterCallback, diskStorage } from 'multer';
+import { Observable } from 'rxjs';
+import { v4 } from 'uuid';
+
+// import { MAX_IMAGE_SIZE } from '../../common/constant';
+
+const MAX_IMAGE_SIZE = 1024 * 1024 * 40;
+
+@Injectable()
+export class FileUploadInterceptor implements NestInterceptor<void, void> {
+  async intercept(
+    context: ExecutionContext,
+    next: CallHandler,
+  ): Promise<Observable<void>> {
+    const ctx: HttpArgumentsHost = context.switchToHttp();
+    const req = ctx.getRequest<Request & { filepath?: string }>();
+
+    const multerOptions: multer.Options = {
+      fileFilter: (_req, file: Express.Multer.File, cb: FileFilterCallback) => {
+        if (!file.mimetype.match(/image\/(gif|jpeg|png)/)) {
+          cb(
+            new UnsupportedMediaTypeException(
+              'gif, jpeg, png 형식의 파일만 업로드 가능합니다.',
+            ),
+          );
+        }
+        cb(null, true);
+      },
+      storage: diskStorage({
+        destination: 'public/asset',
+        filename: (_req, file, cb) => {
+          const uuid = v4().substring(0, 6);
+          // const myId = req.headers['x-my-id'];
+          const extArray = file.mimetype.split('/');
+          const filename = `profile-${uuid}.${extArray[extArray.length - 1]}`;
+          req.filepath = `/asset/${filename}`; // 파일 경로를 요청 객체에 추가
+          cb(null, filename);
+        },
+      }),
+      limits: { fileSize: MAX_IMAGE_SIZE },
+    };
+
+    await new Promise<void>((resolve, reject) =>
+      multer(multerOptions).single('thumbnailImage')(
+        ctx.getRequest(),
+        ctx.getResponse(),
+        (error) => {
+          error
+            ? reject(
+                error.code === 'LIMIT_FILE_SIZE'
+                  ? new PayloadTooLargeException(
+                      '이미지 파일은 4MB 이하로 업로드 가능합니다.',
+                    )
+                  : error,
+              )
+            : resolve();
+        },
+      ),
+    );
+    return next.handle();
+  }
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -23,6 +23,8 @@ import { join } from 'path';
     }),
     ServeStaticModule.forRoot({
       rootPath: join(__dirname, '..', 'public'),
+      serveStaticOptions: { index: false, redirect: false },
+      renderPath: '/asset',
     }),
     TypeOrmModule.forRootAsync(TypeOrmConfig),
     AuthModule,


### PR DESCRIPTION
### 📟 연결된 이슈
#29 


### 👷 작업한 내용
- 코스 썸네일을 업로드하거나 수정 시에 파일을 가로채서 저장하고 해당 경로를 db에 저장하는 기능
  - PATCH /admin/courses/:courseId
  - FileUploadInterceptor를 활용하여 중간에 파일만 가로채서 /pulic/asset에 저장
  - 파일 이름은 profile-{uuid}.{ext}
- GET /admin/curriculum
  - 코스 과정 별로 코스 배치하기 위해 코스 과정 데이터를 가져오는 API 구현

### 📸 스크린샷
