### PR TITLE
✨ feat: Admin Quiz API 관리자 퀴즈 관리 API

### DIFF
--- a/src/api/admin/admin.controller.spec.ts
+++ b/src/api/admin/admin.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdminController } from './admin.controller';
+
+describe('AdminController', () => {
+  let controller: AdminController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AdminController],
+    }).compile();
+
+    controller = module.get<AdminController>(AdminController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/api/admin/admin.controller.ts
+++ b/src/api/admin/admin.controller.ts
@@ -6,17 +6,22 @@ import {
   Param,
   Patch,
   Post,
+  Query,
   Req,
   UseInterceptors,
 } from '@nestjs/common';
 import { AdminService } from './admin.service';
-import { UpdateCourseDto } from './dto/update-course.dto';
 import { UpdateLecturesDto } from './dto/update-lectures.dto';
+import { UpdateCourseDto } from './dto/update-course.dto';
 import { FileUploadInterceptor } from './interceptor/fileUploadInterceptor';
+import { Roles } from '../users/decorators/role.decorator';
 import { Request } from 'express';
+import { FeedbackDescriptiveQuiz } from './dto/feedbackDescriptiveQuiz.dto';
+import { CreateQuizDto } from './dto/create-new-quiz.dto';
 import { CreateCourseDto } from './dto/create-course.dto';
 import { DeleteCourseDto } from './dto/delete-course.dto';
 
+@Roles('admin')
 @Controller('admin')
 export class AdminController {
   constructor(private readonly adminService: AdminService) {}
@@ -85,5 +90,45 @@ export class AdminController {
   async findAllCurriculums() {
     const result = await this.adminService.findAllCurriculums();
     return { data: result };
+  }
+  // 가드를 고려하여 Param이 없는 라우트 먼저 선언해야함
+
+  @Get('quizzes')
+  async findQuizData() {
+    return await this.adminService.findQuizAll();
+  }
+
+  @Post('quizzes/feedback/:userId/:quizId')
+  async feedbackDescriptiveQuiz(
+    @Param('userId') userId: number,
+    @Param('quizId') quizId: number,
+    @Body() feedbackDescriptiveQuizDto: FeedbackDescriptiveQuiz,
+  ) {
+    console.log(feedbackDescriptiveQuizDto);
+    return await this.adminService.feedbackQuiz(
+      userId,
+      quizId,
+      feedbackDescriptiveQuizDto,
+    );
+  }
+
+  @Get(':userId')
+  async findOneByUserId(@Param('userId') userId: number) {
+    return await this.adminService.findOneByUserId({ where: { userId } });
+  }
+
+  @Roles('admin')
+  @Get('/quizzes/:userId')
+  getMyQuizList(@Param('userId') userId: number, @Query('type') type: string) {
+    const queryQuizType = type;
+    return this.adminService.findMultipleQuizList(userId, queryQuizType);
+  }
+
+  @Post('/quizzes/register/:lectureId')
+  createNewQuiz(
+    @Param('lectureId') lectureId: number,
+    @Body() createQuizDto: CreateQuizDto,
+  ) {
+    return this.adminService.createNewQuiz(lectureId, createQuizDto);
   }
 }

--- a/src/api/admin/admin.module.ts
+++ b/src/api/admin/admin.module.ts
@@ -1,21 +1,30 @@
 import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { Course } from 'src/entities/course.entity';
-import { Lecture } from 'src/entities/lecture.entity';
-import { Enrollment } from 'src/entities/enrollment.entity';
-import { LectureTimeRecord } from 'src/entities/lectureTimeRecord.entity';
+
 import { AdminController } from './admin.controller';
 import { AdminService } from './admin.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from 'src/entities/user.entity';
+import { LectureTimeRecord } from 'src/entities/lectureTimeRecord.entity';
+import { Quiz } from 'src/entities/quiz.entity';
+import { QuizAnswer } from 'src/entities/quizAnswer.entity';
+import { QuizSubmit } from 'src/entities/quizSubmit.entity';
+import { Course } from 'src/entities/course.entity';
+import { Lecture } from 'src/entities/lecture.entity';
+import { Announcement } from 'src/entities/announcement.entity';
+import { Enrollment } from 'src/entities/enrollment.entity';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([
       User,
+      LectureTimeRecord,
+      Quiz,
+      QuizAnswer,
+      QuizSubmit,
       Course,
       Lecture,
+      Announcement,
       Enrollment,
-      LectureTimeRecord,
     ]),
   ],
   controllers: [AdminController],

--- a/src/api/admin/admin.service.spec.ts
+++ b/src/api/admin/admin.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdminService } from './admin.service';
+
+describe('AdminService', () => {
+  let service: AdminService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AdminService],
+    }).compile();
+
+    service = module.get<AdminService>(AdminService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/api/admin/dto/create-new-quiz.dto.ts
+++ b/src/api/admin/dto/create-new-quiz.dto.ts
@@ -1,0 +1,33 @@
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsBoolean,
+  IsNumber,
+  IsString,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+
+export class CreateQuizDto {
+  @IsString()
+  question: string;
+
+  @IsString()
+  quizType: string;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => QuizItemDto)
+  quizInfo: QuizItemDto[];
+}
+export class QuizItemDto {
+  @IsNumber()
+  @Min(0)
+  itemIndex: number;
+
+  @IsString()
+  item: string;
+
+  @IsBoolean()
+  isAnswer: boolean;
+}

--- a/src/api/admin/dto/feedbackDescriptiveQuiz.dto.ts
+++ b/src/api/admin/dto/feedbackDescriptiveQuiz.dto.ts
@@ -1,0 +1,9 @@
+import { IsBoolean, IsString } from 'class-validator';
+
+export class FeedbackDescriptiveQuiz {
+  @IsString()
+  feedbackComment: string;
+
+  @IsBoolean()
+  corrected: boolean;
+}

--- a/src/api/dashboard/dashboard.controller.ts
+++ b/src/api/dashboard/dashboard.controller.ts
@@ -11,6 +11,8 @@ export class DashboardController {
     return this.dashboardService.findAll(userId);
   }
 
+  // 여기에서 role 규칙을 추가해서, 관리자 계정이면 Params에서 userId를 가져오고,
+  //아니면 AuthUser에서 userId를 가져오게 하는 방식으로 할까?
   @Get('/quizzes')
   getMyQuizList(@AuthUser('userId') userId: number) {
     return this.dashboardService.findQuizList(userId);

--- a/src/api/dashboard/dashboard.service.ts
+++ b/src/api/dashboard/dashboard.service.ts
@@ -81,11 +81,6 @@ export class DashboardService {
       .leftJoinAndSelect('lecture.course', 'course') // 강의가 속한 코스를 추가로 불러옵니다.
       .where('quizSubmit.userId = :userId', { userId })
       .getMany();
-    //   .createQueryBuilder('quizSubmit')
-    //   .leftJoinAndSelect('quizSubmit.quiz', 'quiz')
-    //   .leftJoinAndSelect('quiz.quizAnswers', 'quizAnswer')
-    //   .where('quizSubmit.userId = :userId', { userId })
-    //   .getMany();
 
     // quizId를 기준으로 제출된 퀴즈들을 그룹화합니다.
     const quizMap = new Map();
@@ -128,6 +123,11 @@ export class DashboardService {
         )
       ) {
         quizEntry.isAnswer = false;
+      }
+      if (submit.quiz.quizType !== 'multiple') {
+        if (submit.status === 0) quizEntry.isAnswer = null;
+        else if (submit.status === 1) quizEntry.isAnswer = true;
+        else if (submit.status === 2) quizEntry.isAnswer = false;
       }
     });
 

--- a/src/api/quizzes/dto/create-quizAnswr.dto.ts
+++ b/src/api/quizzes/dto/create-quizAnswr.dto.ts
@@ -1,4 +1,4 @@
-import { IsArray, IsNumber } from 'class-validator';
+import { IsArray, IsNumber, IsOptional, IsString } from 'class-validator';
 
 export class CreateQuizAnswerDto {
   @IsNumber()
@@ -6,4 +6,8 @@ export class CreateQuizAnswerDto {
 
   @IsArray()
   multipleAnswer: number[];
+
+  @IsOptional()
+  @IsString()
+  submittedAnswer: string | null;
 }

--- a/src/api/quizzes/quizzes.controller.ts
+++ b/src/api/quizzes/quizzes.controller.ts
@@ -41,11 +41,10 @@ export class QuizzesController {
   saveUserQuizAnswer(
     @Param('courseId') courseId: number,
     @Param('lectureId') lectureId: number,
-    @AuthUser() user,
+    @AuthUser('userId') userId,
     @Body() data: CreateQuizAnswerDto,
   ) {
-    const userId = user.userId;
-
+    console.log(userId);
     return this.quizzesService.saveUserAnswer(
       courseId,
       lectureId,

--- a/src/api/quizzes/quizzes.service.ts
+++ b/src/api/quizzes/quizzes.service.ts
@@ -99,19 +99,34 @@ export class QuizzesService {
         '이미 답안을 제출한 퀴즈입니다.',
         HttpStatus.BAD_REQUEST,
       );
-    } else {
-      await Promise.all(
-        data.multipleAnswer.map(async (ele) => {
-          const quizAnswerData = this.quizSubmitRepository.create({
-            user: { userId: userId },
-            quiz: { quizId: data.quizId },
-            multipleAnswer: ele,
-          });
-
-          await this.quizSubmitRepository.save(quizAnswerData);
-        }),
-      );
     }
-    return { message: '퀴즈가 성공적으로 제출되었습니다.' };
+    try {
+      if (data.submittedAnswer === null) {
+        await Promise.all(
+          data.multipleAnswer.map(async (ele) => {
+            const quizAnswerData = this.quizSubmitRepository.create({
+              user: { userId: userId },
+              quiz: { quizId: data.quizId },
+              multipleAnswer: ele,
+            });
+
+            await this.quizSubmitRepository.save(quizAnswerData);
+          }),
+        );
+      } else {
+        const DescriptiveAnswerData = this.quizSubmitRepository.create({
+          user: { userId },
+          quiz: { quizId: data.quizId },
+          multipleAnswer: 0,
+          submittedAnswer: data.submittedAnswer,
+        });
+
+        await this.quizSubmitRepository.save(DescriptiveAnswerData);
+      }
+      return { message: '퀴즈가 성공적으로 제출되었습니다.' };
+    } catch (error) {
+      console.log(error);
+      return error;
+    }
   }
 }

--- a/src/api/users/users.controller.ts
+++ b/src/api/users/users.controller.ts
@@ -57,11 +57,6 @@ export class UsersController {
     return result;
   }
 
-  @Get(':userId')
-  async findOneByUserId(@Param('userId') userId: number) {
-    return await this.usersService.findOneByUserId({ where: { userId } });
-  }
-
   @Patch(':userId')
   async updateOneByUserId(
     @Body() dto: UpdateUserDto,

--- a/src/api/users/users.service.ts
+++ b/src/api/users/users.service.ts
@@ -104,28 +104,7 @@ export class UsersService {
     return user;
   }
 
-  async findOneByUserId(where: FindOneOptions<User>) {
-    const user = await this.usersRepository.findOne(where);
-
-    if (!user) {
-      throw new NotFoundException(
-        `There isn't any user with identifier: ${where}`,
-      );
-    }
-
-    return instanceToPlain(user);
-  }
-
   async saveMinutes(minutes: number, userId: number, lectureId: number) {
-    // const result = await this.lectureTimeRecordRepository.update(
-    //   {
-    //     lectureId,
-    //     userId,
-    //   },
-    //   {
-    //     playTime: minutes,
-    //   },
-    // );
     const newRecord = await this.lectureTimeRecordRepository.create({
       lectureId,
       userId,

--- a/src/entities/quizAnswer.entity.ts
+++ b/src/entities/quizAnswer.entity.ts
@@ -18,13 +18,13 @@ export class QuizAnswer {
   @Column({ comment: '퀴즈id' })
   quizId: number;
 
-  @Column({ length: 20, comment: '항목' })
+  @Column({ length: 20, comment: '퀴즈 문항 내용' })
   item: string;
 
-  @Column({ comment: '정답 여부' })
+  @Column({ comment: '해당 문항이 정답인지에 대한 여부' })
   isAnswer: boolean;
 
-  @Column({ length: 10, nullable: true })
+  @Column({ length: 10, nullable: true, default: 'active' })
   status: string;
 
   @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })

--- a/src/entities/quizSubmit.entity.ts
+++ b/src/entities/quizSubmit.entity.ts
@@ -25,7 +25,10 @@ export class QuizSubmit {
   @Column('text', { nullable: true })
   feedbackComment: string;
 
-  @Column({ default: false, comment: '0: 미채점 / 1: 정답 / 2: 오답' })
+  @Column({
+    default: false,
+    comment: '(주관식의 경우) 0: 미채점 / 1: 정답 / 2: 오답',
+  })
   status: number;
 
   @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })


### PR DESCRIPTION
### 📟 연결된 이슈
#8 
.

### 👷 작업한 내용
- 관리자 페이지에서 사용자의 제출 퀴즈를 채점하는 API 설계
- 관리자 페이지에서 강의에 퀴즈를 추가하는 API 설계
- 관리자 페이지 role based로 작업
.

### 📸 스크린샷
