### PR TITLE
✨ feat: admin Quiz CRUD API

### DIFF
--- a/src/api/admin/admin.controller.ts
+++ b/src/api/admin/admin.controller.ts
@@ -127,4 +127,18 @@ export class AdminController {
   ) {
     return this.adminService.createNewQuiz(lectureId, createQuizDto);
   }
+
+  @Patch('/quizzes/edit/:lectureId/:quizId')
+  patchQuizData(
+    @Param('lectureId') lectureId: number,
+    @Param('quizId') quizId: number,
+    @Body() updateQuizDto: CreateQuizDto,
+  ) {
+    return this.adminService.updateQuizData(lectureId, quizId, updateQuizDto);
+  }
+
+  @Delete('/quizzes/delete/:quizId')
+  deleteQiuz(@Param('quizId') quizId: number) {
+    return this.adminService.deleteQuiz(quizId);
+  }
 }

--- a/src/entities/quiz.entity.ts
+++ b/src/entities/quiz.entity.ts
@@ -41,9 +41,13 @@ export class Quiz {
   @JoinColumn({ name: 'lectureId' })
   lecture: Lecture;
 
-  @OneToMany(() => QuizSubmit, (quizSubmit) => quizSubmit.quiz)
+  @OneToMany(() => QuizSubmit, (quizSubmit) => quizSubmit.quiz, {
+    cascade: true,
+  })
   quizSubmits: QuizSubmit[];
 
-  @OneToMany(() => QuizAnswer, (quizAnswer) => quizAnswer.quiz)
+  @OneToMany(() => QuizAnswer, (quizAnswer) => quizAnswer.quiz, {
+    cascade: true,
+  })
   quizAnswers: QuizAnswer[];
 }

--- a/src/entities/quizAnswer.entity.ts
+++ b/src/entities/quizAnswer.entity.ts
@@ -37,7 +37,9 @@ export class QuizAnswer {
   })
   updatedAt: Date;
 
-  @ManyToOne(() => Quiz, (quiz) => quiz.quizAnswers)
+  @ManyToOne(() => Quiz, (quiz) => quiz.quizAnswers, {
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'quizId' })
   quiz: Quiz;
 }

--- a/src/entities/quizSubmit.entity.ts
+++ b/src/entities/quizSubmit.entity.ts
@@ -41,7 +41,9 @@ export class QuizSubmit {
   })
   updatedAt: Date;
 
-  @ManyToOne(() => Quiz, (quiz) => quiz.quizSubmits)
+  @ManyToOne(() => Quiz, (quiz) => quiz.quizSubmits, {
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'quizId' })
   quiz: Quiz;
 


### PR DESCRIPTION
관리자페이지 퀴즈 수정 기능

### 📟 연결된 이슈
#35 
.

### 👷 작업한 내용
- 관리자 페이지에서 퀴즈 정보를 수정하고 삭제할 수 있는 API 추가
PATCH /admin/quizzes/edit/:lectureId/:quizId
DELETE /admin/quizzes/delete/:quizId
.

### 📸 스크린샷
