### PR TITLE
add : jenkins for CI/CD

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,35 +1,67 @@
-version: '3.8'
+version: "3.8"
 
 services:
   mysql:
     image: mysql:latest
     ports:
-      - '3306:3306'
+      - "3306:3306"
     environment:
-      - MYSQL_ROOT_PASSWORD=Rhcehdtksdkzkepal*
-      - MYSQL_DATABASE=fgacademydb
+      MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE=${MYSQL_DATABASE}
     volumes:
       - mysql-data:/var/lib/mysql
     restart: always
 
   app:
-    build: .
-    ports:
-      - '3000:3000'
+    build:
+      context: .
+      dockerfile: Dockerfile.prod
     environment:
-      - NODE_ENV=production
-      - DB_HOST=mysql
-      - DB_USER=root
-      - DB_PASSWORD=Rhcehdtksdkzkepal*
-      - DB_NAME=fgacademydb
-      - EMAILADDRESS=rkdckdfyyd@naver.com
-      - EMAILPASSWORD=spdlqjwhgdk3*
-      - JWT_SECRET=0dd8d1d7c673300e0e800e10e13eb6ee1414c140e046ebf7e2229010ab7ab79a10f06fddeebabfb428b6a380aa12654c
+      - NODE_ENV=${NODE_ENV}
+      - DB_HOST=${DB_HOST}
+      - DB_USER=${DB_USER}
+      - DB_PASSWORD=${DB_PASSWORD}
+      - DB_NAME=${DB_NAME}
+      - EMAILADDRESS=${EMAILADDRESS}
+      - EMAILPASSWORD=${EMAILPASSWORD}
+      - JWT_SECRET=${JWT_SECRET}
     volumes:
       - /FG-Academy-BE/public:/app/public
+    expose:
+      - 8080
     depends_on:
       - mysql
     restart: always
+
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.prod
+    environment:
+      NODE_ENV: production
+    depends_on:
+      - app
+    expose:
+      - 3000
+    restart: always
+    extra_hosts:
+      - host.docker.internal:host-gateway
+
+  nginx:
+    image: nginx:latest
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf
+      - ./FG-Academy-BE/public:/var/www/html
+      - ./FG-Academy-BE/log/directory:/var/log/nginx
+    depends_on:
+      - frontend
+      - app
+    restart: always
+    extra_hosts:
+      - host.docker.internal:host-gateway
 
 volumes:
   mysql-data:


### PR DESCRIPTION
### 📟 연결된 이슈

.

### 👷 작업한 내용
현재 도커 네트워크 브리지를 분리해서 작업하지 않고 통합된 네트워크 안에서 작업하는 기준으로 CI/CD 구축하였음
repo에 있던 docker-compose.yml을 서버에 기존 docker-compose.prod.yml로 대체하고 환경변수 값은 파라미터로
jenkinsscript안에서 참조하도록 변경하였음 (repo가 public이라 환경 변수값은 노출되는 것은 보안상 적절치 못함)

실햄 흐름
1) main repo 변화 감지 -> jenkins pipeline build -> docker-compose down -> docker-compose up -> main repo에 있는 docker-compose.yml 참조해서 실행 -> jenkins 워크스페이스에서 Dockerfile build 실행 
.

### 📸 스크린샷
